### PR TITLE
feat(npm): add JS entry exposing getPath() for the wasm

### DIFF
--- a/dprint_plugin/deployment/npm/README.md
+++ b/dprint_plugin/deployment/npm/README.md
@@ -1,0 +1,33 @@
+# dprint-plugin-yaml
+
+npm distribution of the [Pretty YAML](https://github.com/g-plane/pretty_yaml) [dprint](https://dprint.dev/) plugin.
+
+## Install
+
+```shell
+npm install --save dprint-plugin-yaml
+```
+
+## Usage
+
+Use this package to get the path to the plugin's Wasm module from JavaScript:
+
+```js
+import { getPath } from "dprint-plugin-yaml";
+
+// or:
+const { getPath } = require("dprint-plugin-yaml");
+
+// absolute path to the Wasm module:
+getPath();
+```
+
+The Wasm file is also reachable directly via the `dprint-plugin-yaml/plugin.wasm` subpath export.
+
+## Configuring dprint
+
+To use the plugin from `dprint.json` directly, see the instructions in the [main README](https://github.com/g-plane/pretty_yaml#dprint). Configuration options are documented at <https://pretty-yaml.netlify.app/>.
+
+## License
+
+MIT

--- a/dprint_plugin/deployment/npm/index.d.ts
+++ b/dprint_plugin/deployment/npm/index.d.ts
@@ -1,0 +1,1 @@
+export function getPath(): string;

--- a/dprint_plugin/deployment/npm/index.js
+++ b/dprint_plugin/deployment/npm/index.js
@@ -1,0 +1,11 @@
+/**
+ * Gets the path to the Wasm module.
+ * @returns {string}
+ */
+function getPath() {
+  return require("path").join(__dirname, "plugin.wasm");
+}
+
+module.exports = {
+  getPath,
+};

--- a/dprint_plugin/deployment/npm/package.json
+++ b/dprint_plugin/deployment/npm/package.json
@@ -14,6 +14,7 @@
   "files": [
     "index.js",
     "index.d.ts",
+    "README.md",
     "*.wasm"
   ],
   "exports": {

--- a/dprint_plugin/deployment/npm/package.json
+++ b/dprint_plugin/deployment/npm/package.json
@@ -5,15 +5,22 @@
   "author": "Pig Fang <g-plane@hotmail.com>",
   "repository": "g-plane/pretty_yaml",
   "license": "MIT",
-  "type": "module",
   "keywords": [
     "dprint",
     "dprint-plugin"
   ],
+  "main": "./index.js",
+  "types": "./index.d.ts",
   "files": [
+    "index.js",
+    "index.d.ts",
     "*.wasm"
   ],
   "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "default": "./index.js"
+    },
     "./plugin.wasm": "./plugin.wasm",
     "./package.json": "./package.json"
   }


### PR DESCRIPTION
## Summary

The published `dprint-plugin-yaml` npm package currently ships no JS entry — `import "dprint-plugin-yaml"` fails, and the package has no loader API on par with the sibling `@dprint/typescript`, `@dprint/json`, `@dprint/markdown`, `@dprint/toml`, and `@dprint/dockerfile` packages, which all export a small `getPath()` returning the absolute path to the bundled `plugin.wasm`.

This PR adds the same entry:

- `index.js` — CommonJS, `module.exports = { getPath }` returning `path.join(__dirname, "plugin.wasm")` (identical to the other dprint plugin packages).
- `index.d.ts` — `export function getPath(): string;`.
- `package.json` — adds `main`, `types`, a `"."` conditional export, lists the new files. The previously-inert `"type": "module"` field is removed so the CJS entry parses; no JS was shipped before, so nothing relied on it.
- `README.md` — short npm-package README documenting the API, mirroring the other dprint plugins.

The existing `./plugin.wasm` and `./package.json` subpath exports are preserved unchanged, so consumers that resolve `dprint-plugin-yaml/plugin.wasm` keep working. The change is purely additive on the exports side.

The release workflow already does `cp ... plugin.wasm` into `dprint_plugin/deployment/npm/` and `npm publish`es from there, so no workflow change is needed — the new files ship on the next release.

## Test plan

- [x] `npm pack --dry-run` lists `index.js`, `index.d.ts`, `README.md`, `package.json`, `plugin.wasm`.
- [x] In a scratch project with the package installed, `require("dprint-plugin-yaml").getPath()` returns an absolute path that exists.
- [x] `import { getPath } from "dprint-plugin-yaml"` (ESM) works via Node's CJS→ESM named-export interop.
- [x] `require.resolve("dprint-plugin-yaml/plugin.wasm")` still resolves to the same path (no regression for existing consumers).